### PR TITLE
style: adjust footer margin for better spacing

### DIFF
--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="text-gray-500 mb-10">
+  <footer class="text-gray-500 my-10">
     <ul>
       <li class="flex justify-center gap-3">
         <a


### PR DESCRIPTION
The margin-bottom (mb-10) was replaced with margin-top and margin-bottom (my-10) to ensure consistent spacing around the footer element.