### PR TITLE
refactor(documents): remove outdated document link and update article…

### DIFF
--- a/content/articles/computer-science-fundamentals/index.md
+++ b/content/articles/computer-science-fundamentals/index.md
@@ -1,12 +1,12 @@
 ---
-title: Computer Science Fundamentals 
+title: Computer Science Fundamentals
 description: A comprehensive guide covering essential topics in Computer Networks and Database Systems
 date: 2025-02-14
 ---
 
 ## Computer Networks
 
-- Network Transmission and Performance 
+- Network Transmission and Performance
 - Link Layer
 - Ethernet and Switching
 - Distance Vector Routing
@@ -39,3 +39,10 @@ date: 2025-02-14
 - Recovery (logging, checkpoints)
 - Query processing (joins, sorting, aggregation, optimization)
 - Parallel architectures (multi-core, distributed)
+
+## Learning Resources
+
+- [CMU 15-441/641, Fall 2024](https://psteenkiste.github.io/nets-fa24/)
+- [CMU 15-445/645 Spring 2024](https://15445.courses.cs.cmu.edu/spring2024/)
+- [CS 61B Spring 2024](https://sp24.datastructur.es/)
+- [CS 61B Textbook](https://cs61b-2.gitbook.io/cs61b-textbook)

--- a/pages/documents.vue
+++ b/pages/documents.vue
@@ -27,11 +27,6 @@ const documents: readonly Document[] = [
     name: "Distributed Systems for practitioners.pdf",
     url: "https://drive.proton.me/urls/4V00RDET1G#dNvNhhC7YqWJ",
   },
-  {
-    id: "2",
-    name: "CMU 15-441/641: Networking and the Internet, Fall 2024",
-    url: "https://drive.proton.me/urls/DQ7SVVNKT0#VCjlIl1U6M88",
-  },
 ] as const
 
 const isEmpty = computed(() => documents.length === 0)


### PR DESCRIPTION
… formatting

The CMU 15-441/641 document link was removed as it is no longer relevant. Additionally, minor formatting improvements were made to the computer science fundamentals article, including consistent spacing and the addition of learning resources.